### PR TITLE
Integrate Travis CI for Continuous Integration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,11 @@
+nguage: python
+python:
+  - "3.6"
+  - "3.6-dev"  # 3.6 development branch
+# command to install dependencies
+install:
+  - pip install -r requirements.txt
+  - pip install -e .
+# command to run tests
+script:
+  - pytest


### PR DESCRIPTION
This is a PR to add a CI pipeline using Travis to do build checks

There are currenty no tests implemented for pytests, but still at least we know that it builds