### PR TITLE
Get rid of GNU license headers

### DIFF
--- a/gym_reinmav/envs/mujoco/mujoco_quad.py
+++ b/gym_reinmav/envs/mujoco/mujoco_quad.py
@@ -1,3 +1,36 @@
+# **********************************************************************
+#
+# Copyright (c) 2019, Autonomous Systems Lab
+# Author: Dongho Kang <eastsky.kang@gmail.com>
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+# 1. Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+# 2. Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in
+#    the documentation and/or other materials provided with the
+#    distribution.
+# 3. Neither the name PX4 nor the names of its contributors may be
+#    used to endorse or promote products derived from this software
+#    without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+# FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+# COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+# INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+# BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+# OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+# AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+# LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+# ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+#
+# *************************************************************************
 import numpy as np
 import os
 from gym import utils

--- a/gym_reinmav/envs/mujoco/mujoco_quad_hovering.py
+++ b/gym_reinmav/envs/mujoco/mujoco_quad_hovering.py
@@ -1,3 +1,36 @@
+# **********************************************************************
+#
+# Copyright (c) 2019, Autonomous Systems Lab
+# Author: Dongho Kang <eastsky.kang@gmail.com>
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+# 1. Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+# 2. Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in
+#    the documentation and/or other materials provided with the
+#    distribution.
+# 3. Neither the name PX4 nor the names of its contributors may be
+#    used to endorse or promote products derived from this software
+#    without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+# FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+# COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+# INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+# BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+# OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+# AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+# LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+# ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+#
+# *************************************************************************
 import numpy as np
 import os
 

--- a/gym_reinmav/envs/mujoco/mujoco_quad_quat.py
+++ b/gym_reinmav/envs/mujoco/mujoco_quad_quat.py
@@ -1,3 +1,36 @@
+# **********************************************************************
+#
+# Copyright (c) 2019, Autonomous Systems Lab
+# Author: Dongho Kang <eastsky.kang@gmail.com>
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+# 1. Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+# 2. Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in
+#    the documentation and/or other materials provided with the
+#    distribution.
+# 3. Neither the name PX4 nor the names of its contributors may be
+#    used to endorse or promote products derived from this software
+#    without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+# FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+# COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+# INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+# BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+# OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+# AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+# LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+# ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+#
+# *************************************************************************
 import numpy as np
 import os
 

--- a/gym_reinmav/envs/native/quadrotor2d.py
+++ b/gym_reinmav/envs/native/quadrotor2d.py
@@ -1,20 +1,36 @@
-#Copyright (C) 2018, by Jaeyoung Lim, jaeyoung@auterion.com
-# 2D quadrotor environment using rate control inputs (continuous control)
-
-#This is free software: you can redistribute it and/or modify
-#it under the terms of the GNU Lesser General Public License as published by
-#the Free Software Foundation, either version 3 of the License, or
-#(at your option) any later version.
- 
-#This software package is distributed in the hope that it will be useful,
-#but WITHOUT ANY WARRANTY; without even the implied warranty of
-#MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#GNU Lesser General Public License for more details.
-
-#You should have received a copy of the GNU Leser General Public License.
-#If not, see <http://www.gnu.org/licenses/>.
-
-
+# **********************************************************************
+#
+# Copyright (c) 2019, Autonomous Systems Lab
+# Author: Jaeyoung Lim <jalim@student.ethz.ch>
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+# 1. Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+# 2. Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in
+#    the documentation and/or other materials provided with the
+#    distribution.
+# 3. Neither the name PX4 nor the names of its contributors may be
+#    used to endorse or promote products derived from this software
+#    without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+# FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+# COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+# INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+# BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+# OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+# AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+# LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+# ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+#
+# *************************************************************************
 import gym
 from gym import error, spaces, utils, logger
 from math import cos, sin, pi, atan2

--- a/gym_reinmav/envs/native/quadrotor2d_slungload.py
+++ b/gym_reinmav/envs/native/quadrotor2d_slungload.py
@@ -1,20 +1,36 @@
-#Copyright (C) 2018, by Jaeyoung Lim, jaeyoung@auterion.com
-# 2D quadrotor slungload system environment using rate control inputs (continuous control)
-
-#This is free software: you can redistribute it and/or modify
-#it under the terms of the GNU Lesser General Public License as published by
-#the Free Software Foundation, either version 3 of the License, or
-#(at your option) any later version.
- 
-#This software package is distributed in the hope that it will be useful,
-#but WITHOUT ANY WARRANTY; without even the implied warranty of
-#MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#GNU Lesser General Public License for more details.
-
-#You should have received a copy of the GNU Leser General Public License.
-#If not, see <http://www.gnu.org/licenses/>.
-
-
+# **********************************************************************
+#
+# Copyright (c) 2019, Autonomous Systems Lab
+# Author: Jaeyoung Lim <jalim@student.ethz.ch>
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+# 1. Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+# 2. Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in
+#    the documentation and/or other materials provided with the
+#    distribution.
+# 3. Neither the name PX4 nor the names of its contributors may be
+#    used to endorse or promote products derived from this software
+#    without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+# FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+# COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+# INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+# BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+# OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+# AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+# LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+# ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+#
+# *************************************************************************
 import gym
 from gym import error, spaces, utils, logger
 from math import cos, sin, pi, atan2

--- a/gym_reinmav/envs/native/quadrotor3d.py
+++ b/gym_reinmav/envs/native/quadrotor3d.py
@@ -1,20 +1,36 @@
-#Copyright (C) 2018, by Jaeyoung Lim, jaeyoung@auterion.com
-# 3D quadrotor environment using rate control inputs (continuous control)
-
-#This is free software: you can redistribute it and/or modify
-#it under the terms of the GNU Lesser General Public License as published by
-#the Free Software Foundation, either version 3 of the License, or
-#(at your option) any later version.
- 
-#This software package is distributed in the hope that it will be useful,
-#but WITHOUT ANY WARRANTY; without even the implied warranty of
-#MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#GNU Lesser General Public License for more details.
-
-#You should have received a copy of the GNU Leser General Public License.
-#If not, see <http://www.gnu.org/licenses/>.
-
-
+# **********************************************************************
+#
+# Copyright (c) 2019, Autonomous Systems Lab
+# Author: Jaeyoung Lim <jalim@student.ethz.ch>
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+# 1. Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+# 2. Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in
+#    the documentation and/or other materials provided with the
+#    distribution.
+# 3. Neither the name PX4 nor the names of its contributors may be
+#    used to endorse or promote products derived from this software
+#    without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+# FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+# COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+# INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+# BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+# OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+# AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+# LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+# ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+#
+# *************************************************************************
 import gym
 from gym import error, spaces, utils, logger
 from math import cos, sin, pi, atan2

--- a/gym_reinmav/envs/native/quadrotor3d_slungload.py
+++ b/gym_reinmav/envs/native/quadrotor3d_slungload.py
@@ -1,20 +1,36 @@
-#Copyright (C) 2018, by Jaeyoung Lim, jaeyoung@auterion.com
-# 3D quadrotor environment using rate control inputs (continuous control)
-
-#This is free software: you can redistribute it and/or modify
-#it under the terms of the GNU Lesser General Public License as published by
-#the Free Software Foundation, either version 3 of the License, or
-#(at your option) any later version.
- 
-#This software package is distributed in the hope that it will be useful,
-#but WITHOUT ANY WARRANTY; without even the implied warranty of
-#MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#GNU Lesser General Public License for more details.
-
-#You should have received a copy of the GNU Leser General Public License.
-#If not, see <http://www.gnu.org/licenses/>.
-
-
+# **********************************************************************
+#
+# Copyright (c) 2019, Autonomous Systems Lab
+# Author: Jaeyoung Lim <jalim@student.ethz.ch>
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+# 1. Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+# 2. Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in
+#    the documentation and/or other materials provided with the
+#    distribution.
+# 3. Neither the name PX4 nor the names of its contributors may be
+#    used to endorse or promote products derived from this software
+#    without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+# FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+# COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+# INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+# BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+# OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+# AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+# LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+# ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+#
+# *************************************************************************
 import gym
 from gym import error, spaces, utils, logger
 from math import cos, sin, pi, atan2

--- a/gym_reinmav/envs/native/reinmav_env.py
+++ b/gym_reinmav/envs/native/reinmav_env.py
@@ -1,20 +1,36 @@
-#Copyright (C) 2018, by Inkyu Sa, enddl22@gmail.com
-# Adaptation of the MountainCar Environment (continuous control)
-
-#This is free software: you can redistribute it and/or modify
-#it under the terms of the GNU Lesser General Public License as published by
-#the Free Software Foundation, either version 3 of the License, or
-#(at your option) any later version.
- 
-#This software package is distributed in the hope that it will be useful,
-#but WITHOUT ANY WARRANTY; without even the implied warranty of
-#MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#GNU Lesser General Public License for more details.
-
-#You should have received a copy of the GNU Leser General Public License.
-#If not, see <http://www.gnu.org/licenses/>.
-
-
+# **********************************************************************
+#
+# Copyright (c) 2018, Autonomous Systems Lab
+# Author: Inkyu Sa <enddl22@gmail.com>
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+# 1. Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+# 2. Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in
+#    the documentation and/or other materials provided with the
+#    distribution.
+# 3. Neither the name PX4 nor the names of its contributors may be
+#    used to endorse or promote products derived from this software
+#    without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+# FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+# COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+# INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+# BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+# OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+# AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+# LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+# ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+#
+# *************************************************************************
 import gym
 from gym import error, spaces, utils
 from gym.utils import seeding

--- a/gym_reinmav/example/mujoco/control_quat.py
+++ b/gym_reinmav/example/mujoco/control_quat.py
@@ -1,20 +1,36 @@
-# Copyright (C) 2018, by Jaeyoung Lim, jaeyoung@auterion.com
-# 3D quadrotor environment using rate control inputs (continuous control)
-
-# This is free software: you can redistribute it and/or modify
-# it under the terms of the GNU Lesser General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-
-# This software package is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU Lesser General Public License for more details.
-
-# You should have received a copy of the GNU Leser General Public License.
-# If not, see <http://www.gnu.org/licenses/>.
-
-
+# **********************************************************************
+#
+# Copyright (c) 2019, Autonomous Systems Lab
+# Author: Dongho Kang <eastsky.kang@gmail.com>
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+# 1. Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+# 2. Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in
+#    the documentation and/or other materials provided with the
+#    distribution.
+# 3. Neither the name PX4 nor the names of its contributors may be
+#    used to endorse or promote products derived from this software
+#    without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+# FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+# COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+# INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+# BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+# OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+# AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+# LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+# ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+#
+# *************************************************************************
 import gym
 import numpy as np
 from numpy import linalg

--- a/gym_reinmav/example/mujoco/control_rpy.py
+++ b/gym_reinmav/example/mujoco/control_rpy.py
@@ -1,3 +1,36 @@
+# **********************************************************************
+#
+# Copyright (c) 2019, Autonomous Systems Lab
+# Author: Dongho Kang <eastsky.kang@gmail.com>
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+# 1. Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+# 2. Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in
+#    the documentation and/or other materials provided with the
+#    distribution.
+# 3. Neither the name PX4 nor the names of its contributors may be
+#    used to endorse or promote products derived from this software
+#    without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+# FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+# COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+# INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+# BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+# OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+# AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+# LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+# ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+#
+# *************************************************************************
 import gym
 import numpy as np
 

--- a/test/test_quadrotor2d.py
+++ b/test/test_quadrotor2d.py
@@ -1,19 +1,3 @@
-#Copyright (C) 2018, by Jaeyoung Lim, jalim@student.ethz.ch
-# 2D quadrotor environment using rate control inputs  (continuous control)
-
-#This is free software: you can redistribute it and/or modify
-#it under the terms of the GNU Lesser General Public License as published by
-#the Free Software Foundation, either version 3 of the License, or
-#(at your option) any later version.
- 
-#This software package is distributed in the hope that it will be useful,
-#but WITHOUT ANY WARRANTY; without even the implied warranty of
-#MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#GNU Lesser General Public License for more details.
-
-#You should have received a copy of the GNU Leser General Public License.
-#If not, see <http://www.gnu.org/licenses/>.
-
 # core modules
 import unittest
 

--- a/test/test_quadrotor2dslungload.py
+++ b/test/test_quadrotor2dslungload.py
@@ -1,19 +1,3 @@
-#Copyright (C) 2018, by Jaeyoung Lim, jalim@student.ethz.ch
-# 2D quadrotor slungload system environment using rate control inputs (continuous control)
-
-#This is free software: you can redistribute it and/or modify
-#it under the terms of the GNU Lesser General Public License as published by
-#the Free Software Foundation, either version 3 of the License, or
-#(at your option) any later version.
- 
-#This software package is distributed in the hope that it will be useful,
-#but WITHOUT ANY WARRANTY; without even the implied warranty of
-#MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#GNU Lesser General Public License for more details.
-
-#You should have received a copy of the GNU Leser General Public License.
-#If not, see <http://www.gnu.org/licenses/>.
-
 # core modules
 import unittest
 

--- a/test/test_quadrotor3d.py
+++ b/test/test_quadrotor3d.py
@@ -1,19 +1,3 @@
-#Copyright (C) 2018, by Jaeyoung Lim, jalim@student.ethz.ch
-# 2D quadrotor environment using rate control inputs  (continuous control)
-
-#This is free software: you can redistribute it and/or modify
-#it under the terms of the GNU Lesser General Public License as published by
-#the Free Software Foundation, either version 3 of the License, or
-#(at your option) any later version.
- 
-#This software package is distributed in the hope that it will be useful,
-#but WITHOUT ANY WARRANTY; without even the implied warranty of
-#MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#GNU Lesser General Public License for more details.
-
-#You should have received a copy of the GNU Leser General Public License.
-#If not, see <http://www.gnu.org/licenses/>.
-
 # core modules
 import unittest
 

--- a/test/test_quadrotor3dslungload.py
+++ b/test/test_quadrotor3dslungload.py
@@ -1,19 +1,3 @@
-#Copyright (C) 2018, by Jaeyoung Lim, jalim@student.ethz.ch
-# 2D quadrotor environment using rate control inputs  (continuous control)
-
-#This is free software: you can redistribute it and/or modify
-#it under the terms of the GNU Lesser General Public License as published by
-#the Free Software Foundation, either version 3 of the License, or
-#(at your option) any later version.
- 
-#This software package is distributed in the hope that it will be useful,
-#but WITHOUT ANY WARRANTY; without even the implied warranty of
-#MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#GNU Lesser General Public License for more details.
-
-#You should have received a copy of the GNU Leser General Public License.
-#If not, see <http://www.gnu.org/licenses/>.
-
 # core modules
 import unittest
 

--- a/test/test_reinmav.py
+++ b/test/test_reinmav.py
@@ -1,19 +1,3 @@
-#Copyright (C) 2018, by Inkyu Sa, enddl22@gmail.com
-# Adaptation of the MountainCar Environment (continuous control)
-
-#This is free software: you can redistribute it and/or modify
-#it under the terms of the GNU Lesser General Public License as published by
-#the Free Software Foundation, either version 3 of the License, or
-#(at your option) any later version.
- 
-#This software package is distributed in the hope that it will be useful,
-#but WITHOUT ANY WARRANTY; without even the implied warranty of
-#MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#GNU Lesser General Public License for more details.
-
-#You should have received a copy of the GNU Leser General Public License.
-#If not, see <http://www.gnu.org/licenses/>.
-
 # core modules
 import unittest
 


### PR DESCRIPTION
This PR gets rid of the GNU license headers which were present in the code and
- Switch it to BSD license
- Get rid of insignifcant headers